### PR TITLE
initial logic with fast API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,12 @@
 from typing import Literal
 from typing_extensions import TypedDict
 
+from fastapi import FastAPI
+from langserve import add_routes
 from langchain_openai import ChatOpenAI
 from langgraph.graph import MessagesState, END
 from langgraph.types import Command
+import re
 
 from langchain_core.messages import HumanMessage
 from langgraph.graph import StateGraph, START, END
@@ -61,7 +64,7 @@ def supervisor_node(state: State) -> Command[Literal["pharmacist", "researcher",
     if goto == "FINISH":
         goto = END
 
-    return Command(goto=goto, update={"next": goto})
+    return Command(goto=goto if goto != "FINISH" else END, update={"next": goto})
 
 
 pharamcist_agent = create_react_agent(
@@ -124,16 +127,29 @@ with open("graph_image.png", "wb") as f:
     f.write(graph_image)
 
 
-for s in graph.stream(
-    {
-        "messages": [
-            (
-                "user",
-                "What are some current trends in medical imaging?",
-            )
-        ]
-    },
-    subgraphs=True,
-):
-    print(s)
-    print("----")
+app = FastAPI()
+
+@app.get("/")
+def home():
+    return {"message": "Welcome to the RadSys API"}
+
+add_routes(app, graph, path="/graph")
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+# for s in graph.stream(
+#     {
+#         "messages": [
+#             (
+#                 "user",
+#                 "What are some current trends in medical imaging?",
+#             )
+#         ]
+#     },
+#     subgraphs=True,
+# ):
+#     print(s)
+#     print("----")


### PR DESCRIPTION
I set up how to route the functions using FastAPI and LangServe, but I am having issues locally installing the module (my mac won't recognize it for whatever reason?), so was wondering if anyone is able to test it



Here is a sample command to run:
curl -X POST "http://localhost:8000/graph/invoke" -H "Content-Type: application/json" -d '{"messages": [{"role": "user", "content": "Tell me about aspirin."}]}'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a web API interface featuring a welcoming homepage and an integrated route for accessing graphical functionalities.
  
- **Bug Fixes**
  - Refined command handling to ensure smoother session termination and improved response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->