### PR TITLE
address PR #51 feedback and align Linux-first guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,43 @@ RadSysX currently has two parallel product surfaces:
 
 Do not treat those surfaces as equivalent.
 
+## Host Environment Posture
+
+The primary development and validation target is now a native Linux host.
+
+Rules:
+
+- Do not assume WSL, Windows path translation, Docker Desktop integration, `fnm`, or any Windows-only shell behavior.
+- Do not rely on machine-specific temporary dependency paths, ad hoc `PYTHONPATH` overrides, or globally preinstalled packages that are not documented.
+- Prefer a repo-local Python virtual environment in `.venv` and the workspace `package.json` / lockfile state for Node dependencies.
+- Treat Docker Engine + Compose on Linux as the reference container runtime, not Docker Desktop-specific behavior.
+- On a fresh Linux host, first do a quick repo/context recon, then stop and wait for the user's report about what happened during the first Linux app test pass before making deeper code changes.
+
+For future Linux bring-up, prefer this bootstrap sequence:
+
+- `python3 -m venv .venv`
+- `. .venv/bin/activate`
+- `python3 -m pip install --upgrade pip`
+- `python3 -m pip install -r backend/requirements.txt`
+- `npm install --legacy-peer-deps`
+
+If the host is missing a required system dependency, surface that explicitly instead of patching around it with host-local hacks.
+
+## Project Operating Rules
+
+These rules are intended to keep RadSysX coherent as the clinical platform hardens and the repo continues to carry both research and clinical surfaces.
+
+1. Update docs in the same tranche as code when behavior, architecture, env vars, commands, or operational expectations change.
+2. Treat `AGENTS.md` as the authoritative guide and keep `README.md`, `CLAUDE.md`, `WARP.md`, and active checklists aligned instead of letting them drift.
+3. Keep the research and clinical surfaces explicitly separated; do not solve a clinical gap by routing through a research-only shortcut.
+4. Prefer backend-authoritative contracts over browser-local state or inferred client behavior whenever clinical workflow, actor identity, reporting, AI, DICOM, or audit data is involved.
+5. Keep the viewer bootstrap minimal; if behavior can live in an OHIF extension, mode, service, or backend contract, move it there.
+6. Never normalize insecure local habits into maintained guidance: no committed live credentials, no PHI-bearing URLs, no casual identifier logging, and no dependence on machine-local temp paths.
+7. Make environment setup reproducible from the repo itself: `.venv`, declared Python requirements, workspace-managed npm installs, and env-driven secrets.
+8. When review comments expose a real defect or ambiguity, fix the code and also capture the durable lesson in guidance or checklists if it is likely to recur.
+9. After substantial changes, record what was actually verified and what was not; do not imply Docker, viewer, or end-to-end validation if it did not happen.
+10. On new machines or major environment transitions, do initial recon first, then anchor the next decisions to observed runtime behavior from the first user-reported test pass.
+
 ## Primary Runtime Paths
 
 ### Clinical path
@@ -209,22 +246,32 @@ Additional clinical rules:
 
 Preferred focused checks for the clinical slice:
 
-- `python -m pytest backend/tests/test_clinical_platform.py`
-- `python -m compileall backend/clinical backend/server.py`
+- `python3 -m pytest backend/tests/test_clinical_platform.py`
+- `python3 -m compileall backend/clinical backend/server.py backend/radsysx.py`
 - `npm run type-check --workspace frontend`
 - `npm run type-check --workspace viewer`
 - `npm run build --workspace viewer`
 
 Use broader suites only when the change demands it.
 
-If Docker Desktop with WSL integration is available, also validate the composed stack with Orthanc and nginx rather than assuming the local shell/dev servers are equivalent.
+Install missing Python dependencies into `.venv`; do not normalize one-off temp-path dependency shims as part of the expected workflow.
+
+If Docker Engine and Compose are available on the Linux host, also validate the composed stack with Orthanc and nginx rather than assuming the local shell/dev servers are equivalent.
 
 ## Commands
 
+### Linux Bootstrap
+
+- `python3 -m venv .venv`
+- `. .venv/bin/activate`
+- `python3 -m pip install --upgrade pip`
+- `python3 -m pip install -r backend/requirements.txt`
+- `npm install --legacy-peer-deps`
+
 ### Backend
 
-- `cd backend && python server.py`
-- `python -m pytest backend/tests/test_clinical_platform.py`
+- `. .venv/bin/activate && python3 backend/server.py`
+- `. .venv/bin/activate && python3 -m pytest backend/tests/test_clinical_platform.py`
 
 ### Frontend / Workspace
 
@@ -237,6 +284,8 @@ If Docker Desktop with WSL integration is available, also validate the composed 
 
 ### Local Clinical Stack
 
+- `export RADSYSX_ORTHANC_USERNAME=local-user`
+- `export RADSYSX_ORTHANC_PASSWORD=local-pass`
 - `docker compose up --build`
 - clinical public origin: `http://localhost:3000`
 - Next.js shell: `/`
@@ -279,10 +328,11 @@ The next major steps are:
 
 ## Recommended Next Tranche Plan
 
-If starting fresh after Phase 3, do the next tranche in this order:
+If starting from the current post-Phase-4-polish baseline, do the next tranche in this order:
 
-1. Keep the hardening/docs pass current with the shipped RadSysX runtime: secrets, auth mode enforcement, cookie posture, URL secrecy, streamed STOW handoff, and de-identified local scaffolding.
-2. Deepen the OHIF-native integration: move any remaining viewer-specific workflow logic from bootstrap-time helpers into extension/mode/service seams while preserving the opaque launch contract and backend-authoritative workspace behavior.
-3. Finish standards-native writeback: connect OHIF measurement tracking and segmentation flows directly to backend-mediated SR/SEG export through `POST /api/derived-results/stow`, then rehydrate those stored objects from Orthanc on reload.
-4. Validate the real local stack: run the nginx + frontend + viewer + backend + Orthanc compose stack and prove the end-to-end workflow for login, worklist launch, OHIF load, report save/finalize, shadow AI queueing, SR persistence, SEG persistence, workspace refresh, and audit visibility.
-5. Only after viewer/archive realism is stable, move to institutional identity/context: replace the seeded local personas with real identity/provider integration and begin the shift from seeded worklist data toward institutional context.
+1. Do a quick Linux host recon, then wait for the user's first Linux test report so the next fixes are grounded in observed runtime behavior rather than assumptions.
+2. Keep the hardening/docs pass current with the shipped RadSysX runtime: secrets, auth mode enforcement, cookie posture, URL secrecy, streamed STOW handoff, and de-identified local scaffolding.
+3. Deepen the OHIF-native integration: move any remaining viewer-specific workflow logic from bootstrap-time helpers into extension/mode/service seams while preserving the opaque launch contract and backend-authoritative workspace behavior.
+4. Finish standards-native writeback: connect OHIF measurement tracking and segmentation flows directly to backend-mediated SR/SEG export through `POST /api/derived-results/stow`, then rehydrate those stored objects from Orthanc on reload.
+5. Validate the real local stack: run the nginx + frontend + viewer + backend + Orthanc compose stack and prove the end-to-end workflow for login, worklist launch, OHIF load, report save/finalize, shadow AI queueing, SR persistence, SEG persistence, workspace refresh, and audit visibility.
+6. Only after viewer/archive realism is stable, move to institutional identity/context: replace the seeded local personas with real identity/provider integration and begin the shift from seeded worklist data toward institutional context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,13 @@ RadSysX has two product surfaces:
 
 The clinical path is the migration target. Do not plan against research-only seams when making clinical changes.
 
+## Environment Posture
+
+- Preferred host: native Linux
+- Do not assume WSL, Windows paths, Docker Desktop behavior, or machine-local temp dependency hacks
+- Prefer `.venv` for Python deps and workspace-managed Node deps
+- After initial recon on the Linux host, wait for the user's first Linux runtime test report before widening the change scope
+
 ## Current Clinical Runtime
 
 - Backend authority: `backend/server.py` and `backend/clinical/*`

--- a/PHASE4_CLINICAL_EXECUTION_CHECKLIST.md
+++ b/PHASE4_CLINICAL_EXECUTION_CHECKLIST.md
@@ -1,19 +1,19 @@
-# Phase 4 Clinical Execution Checklist
+# Current Clinical Execution Checklist
 
 Branch context:
 
-- local working branch: `new-dev-1-31-26`
+- local working branch: use the current active branch
 - related architecture guidance: `AGENTS.md`
 - public product/runtime name: `RadSysX`
 
 Purpose:
 
-- Replace the completed PR #50 polish checklist with the current execution list for finishing the clinical OHIF migration.
-- Track the remaining work after the hardening pass, the RadSysX rename, and the removal of viewer fallbacks.
+- Track the remaining work after the clinical OHIF cutover, the RadSysX rename, and the PR #51 hardening/polish fixes.
+- Keep the next tranche grounded in the current shipped baseline rather than earlier migration-phase assumptions.
 
 ## Current Baseline
 
-These items are already the starting point for Phase 4:
+These items are already part of the current post-Phase-4-polish baseline:
 
 - [x] RadSysX is the active runtime name across code, packages, env vars, and active docs.
 - [x] OHIF owns the clinical `/viewer` route.
@@ -33,6 +33,11 @@ These items are already the starting point for Phase 4:
 - Guidance docs describe the shipped architecture accurately enough that a new contributor would not plan against stale assumptions.
 
 ## Execution Checklist
+
+- [ ] Start the native Linux validation tranche correctly.
+  - Use a native Linux host as the reference posture.
+  - Bootstrap Python deps with `.venv` and Node deps with workspace `npm install`.
+  - Do a short context recon, then wait for the user's first Linux runtime test report before broad code changes.
 
 - [ ] Finish documentation alignment across the maintained surface.
   - Update any remaining deploy/runtime docs to reflect `RADSYSX_*` env vars, the no-fallback OHIF viewer, and the current one-origin compose stack.
@@ -69,12 +74,13 @@ These items are already the starting point for Phase 4:
 
 ## Suggested Execution Order
 
-1. Documentation alignment and leftover rename cleanup
-2. Native OHIF extension/mode deepening
-3. SR export + reload wiring
-4. SEG export + reload wiring
-5. End-to-end compose validation
-6. Institutional identity/context preparation
+1. Native Linux validation intake and first observed runtime report
+2. Documentation alignment and leftover rename cleanup
+3. Native OHIF extension/mode deepening
+4. SR export + reload wiring
+5. SEG export + reload wiring
+6. End-to-end compose validation
+7. Institutional identity/context preparation
 
 ## Suggested Verification
 
@@ -83,7 +89,7 @@ These items are already the starting point for Phase 4:
 - `npm run type-check --workspace frontend`
 - `npm run type-check --workspace viewer`
 - `npm run build --workspace viewer`
-- If Docker Desktop with WSL integration is available:
+- If Docker Engine + Compose are available on the Linux host:
   - `RADSYSX_ORTHANC_USERNAME=<user> RADSYSX_ORTHANC_PASSWORD=<pass> docker compose up --build`
 
 ## Guardrails

--- a/README.md
+++ b/README.md
@@ -190,19 +190,43 @@ The most important clinical env vars are:
 
 Research-only integrations such as MCP/FHIR tools and BiomedParse still exist, but they do not define the clinical architecture.
 
+## Host Assumptions
+
+The preferred development and validation host is now native Linux.
+
+Operational guidance:
+
+- use native Linux Python, Node, npm, and Docker Engine / Compose
+- avoid WSL-specific path assumptions or Windows-only toolchain shims
+- do not rely on temporary `PYTHONPATH` hacks or undeclared global dependencies
+- prefer a repo-local `.venv` plus workspace-installed Node dependencies
+- when starting work in a fresh chat on the Linux machine, do a short recon first, then wait for the user's report from the first Linux app test pass before making deeper code changes
+
 ## Local Development
+
+### Prerequisites
+
+- Python 3.12+
+- Node.js 20+
+- npm
+- Docker Engine with Compose plugin if you want the one-origin stack
 
 ### Install
 
 ```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install -r backend/requirements.txt
 npm install --legacy-peer-deps
 ```
 
-Backend dependencies are managed from `backend/requirements.txt`.
+Backend dependencies should be installed into `.venv`, not into ad hoc machine-local paths.
 
 ### Run backend directly
 
 ```bash
+. .venv/bin/activate
 python3 backend/server.py
 ```
 
@@ -215,6 +239,7 @@ npm run dev --workspace frontend
 ### Focused backend checks
 
 ```bash
+. .venv/bin/activate
 python3 -m compileall backend/clinical backend/server.py backend/radsysx.py
 python3 -m pytest backend/tests/test_clinical_platform.py
 ```
@@ -236,6 +261,17 @@ export RADSYSX_ORTHANC_USERNAME=local-user
 export RADSYSX_ORTHANC_PASSWORD=local-pass
 docker compose up --build
 ```
+
+### First Linux Validation Pass
+
+On the new Linux host, the first useful runtime checkpoint is:
+
+1. install dependencies with the `.venv` + `npm install` flow above
+2. run the focused backend and viewer checks
+3. attempt the actual app flow on Linux
+4. report what happened before widening the code-change scope
+
+That first report should ideally cover backend startup, frontend startup, viewer build/load, login, worklist, viewer launch, and compose-stack behavior if Docker is available.
 
 Public routes:
 

--- a/WARP.md
+++ b/WARP.md
@@ -11,6 +11,7 @@ This repository’s authoritative implementation guidance is [AGENTS.md](AGENTS.
 - Shared browser clinical package: `packages/clinical-web/*`
 - Clinical shell: `frontend/app/login/page.tsx`, `frontend/app/worklist/page.tsx`
 - Root `frontend/app/page.tsx`: landing/surface selector, not the clinical viewer
+- Preferred host: native Linux, not WSL-specific tooling assumptions
 
 ## Two Surfaces
 
@@ -22,12 +23,18 @@ Do not treat them as equivalent.
 ## Commands
 
 ```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python3 -m pip install -r backend/requirements.txt
+npm install --legacy-peer-deps
 python3 -m compileall backend/clinical backend/server.py backend/radsysx.py
 python3 -m pytest backend/tests/test_clinical_platform.py
 npm run type-check --workspace frontend
 npm run type-check --workspace viewer
 npm run build --workspace viewer
 ```
+
+After initial recon on the Linux host, wait for the user's first app test report before widening the code-change scope.
 
 Local compose stack:
 

--- a/backend/clinical/seed_orthanc.py
+++ b/backend/clinical/seed_orthanc.py
@@ -110,7 +110,7 @@ def main() -> None:
         else:
             raise RuntimeError("Orthanc DICOMweb endpoint did not become ready in time.")
 
-        for study in SEED_STUDIES:
+        for index, study in enumerate(SEED_STUDIES, start=1):
             existing = client.get(
                 "/studies",
                 params={"StudyInstanceUID": study.study_uid, "limit": 1},
@@ -126,7 +126,7 @@ def main() -> None:
                 headers={"Content-Type": "application/dicom"},
             )
             store.raise_for_status()
-            print(f"Seeded {study.modality} sample study {study.accession_number}")
+            print(f"Seeded sample study {index} ({study.modality})")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_clinical_platform.py
+++ b/backend/tests/test_clinical_platform.py
@@ -347,7 +347,7 @@ def test_stow_endpoint_persists_backend_registered_refs(monkeypatch) -> None:
     assert workspace["derivedResults"][0]["metadata"]["stowFileName"] == "seg.dcm"
 
 
-def test_seed_orthanc_logs_without_study_uids(monkeypatch, capsys) -> None:
+def test_seed_orthanc_logs_without_identifiers(monkeypatch, capsys) -> None:
     pytest.importorskip("pydicom")
 
     try:
@@ -386,8 +386,9 @@ def test_seed_orthanc_logs_without_study_uids(monkeypatch, capsys) -> None:
     seed_orthanc_module.main()
 
     output = capsys.readouterr().out
-    assert "Seeded CT sample study ACC-CT-24001" in output
-    assert "Seeded MR sample study ACC-MR-24017" in output
+    assert "Seeded sample study 1 (CT)" in output
+    assert "Seeded sample study 2 (MR)" in output
     for study in seed_orthanc_module.SEED_STUDIES:
         assert study.study_uid not in output
         assert study.patient_name not in output
+        assert study.accession_number not in output

--- a/deploy/clinical-stack/render-orthanc-config.sh
+++ b/deploy/clinical-stack/render-orthanc-config.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+# Keep this helper POSIX-sh compatible because the Orthanc image only guarantees /bin/sh.
+# Escape once for JSON string encoding, then again for the sed replacement payload.
 escape_json_sed() {
   printf '%s' "$1" | sed \
     -e 's/\\/\\\\/g' \

--- a/deploy/clinical-stack/render-orthanc-config.sh
+++ b/deploy/clinical-stack/render-orthanc-config.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+escape_json_sed() {
+  printf '%s' "$1" | sed \
+    -e 's/\\/\\\\/g' \
+    -e 's/"/\\"/g' | sed \
+    -e 's/[&|\\]/\\&/g'
+}
+
+username_escaped=$(
+  escape_json_sed "${RADSYSX_ORTHANC_USERNAME:?Set RADSYSX_ORTHANC_USERNAME}"
+)
+password_escaped=$(
+  escape_json_sed "${RADSYSX_ORTHANC_PASSWORD:?Set RADSYSX_ORTHANC_PASSWORD}"
+)
+
+sed \
+  -e "s|__RADSYSX_ORTHANC_USERNAME__|${username_escaped}|g" \
+  -e "s|__RADSYSX_ORTHANC_PASSWORD__|${password_escaped}|g" \
+  /etc/orthanc/orthanc.json > /tmp/orthanc.json
+
+exec Orthanc /tmp/orthanc.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,14 +63,10 @@ services:
     environment:
       RADSYSX_ORTHANC_USERNAME: "${RADSYSX_ORTHANC_USERNAME:?Set RADSYSX_ORTHANC_USERNAME}"
       RADSYSX_ORTHANC_PASSWORD: "${RADSYSX_ORTHANC_PASSWORD:?Set RADSYSX_ORTHANC_PASSWORD}"
-    command: >
-      sh -lc "sed
-      -e 's/__RADSYSX_ORTHANC_USERNAME__/$$RADSYSX_ORTHANC_USERNAME/g'
-      -e 's/__RADSYSX_ORTHANC_PASSWORD__/$$RADSYSX_ORTHANC_PASSWORD/g'
-      /etc/orthanc/orthanc.json > /tmp/orthanc.json &&
-      Orthanc /tmp/orthanc.json"
+    command: sh /usr/local/bin/render-orthanc-config.sh
     volumes:
       - ./deploy/clinical-stack/orthanc.json:/etc/orthanc/orthanc.json:ro
+      - ./deploy/clinical-stack/render-orthanc-config.sh:/usr/local/bin/render-orthanc-config.sh:ro
       - orthanc-storage:/var/lib/orthanc/db
 
   orthanc-seed:

--- a/viewer/assets/radsysx-bootstrap.js
+++ b/viewer/assets/radsysx-bootstrap.js
@@ -3,63 +3,129 @@
 /** @typedef {import("@radsysx/clinical-web/contracts").ImagingLaunchResolveResponse} ImagingLaunchResolveResponse */
 /** @typedef {import("@radsysx/clinical-web/contracts").SessionResponse} SessionResponse */
 
-(function radsysxBootstrap() {
+(async function radsysxBootstrap() {
+  const LAUNCH_STORAGE_KEY = "radsysx.clinical.launchToken";
+  const REQUEST_TIMEOUT_MS = 10000;
   const loader = ensureLoader();
   const params = new URLSearchParams(window.location.search);
-  const launchToken = params.get("launch");
+  const launchFromUrl = params.get("launch");
 
-  if (!launchToken && !window.__RADSYSX_LAUNCH__) {
-    fail("The OHIF viewer requires a governed launch session.");
-    return;
-  }
+  window.__RADSYSX_BOOTSTRAP_PROMISE__ = bootstrap();
 
   try {
-    /** @type {SessionResponse} */
-    const session = syncJson("/api/auth/session");
-    if (!session.authenticated || !session.session) {
-      const next = encodeURIComponent(`${window.location.pathname}${window.location.search}`);
-      window.location.replace(`/login?next=${next}`);
-      return;
-    }
-
-    /** @type {ImagingLaunchResolveResponse} */
-    const resolved =
-      window.__RADSYSX_LAUNCH__ ??
-      syncJson(`/api/imaging/launch/resolve?launch=${encodeURIComponent(launchToken ?? "")}`);
-    window.__RADSYSX_LAUNCH__ = resolved;
-    window.__RADSYSX_CLEAN_VIEWER_URL__ = function cleanViewerUrl() {
-      history.replaceState(null, "", window.location.pathname);
-    };
-
-    params.delete("launch");
-    params.set("StudyInstanceUIDs", resolved.context.studyInstanceUID);
-    if (resolved.context.seriesInstanceUIDs?.length) {
-      params.set("SeriesInstanceUIDs", resolved.context.seriesInstanceUIDs.join(","));
-    } else {
-      params.delete("SeriesInstanceUIDs");
-    }
-
-    history.replaceState(null, "", `${window.location.pathname}?${params.toString()}`);
-    loader.dataset.state = "ready";
-    loader.querySelector("[data-role='title']").textContent = "Governed launch resolved";
-    loader.querySelector("[data-role='body']").textContent =
-      "Preparing the OHIF runtime and workspace panels.";
+    await window.__RADSYSX_BOOTSTRAP_PROMISE__;
   } catch (error) {
     fail(error instanceof Error ? error.message : "Unable to bootstrap the viewer.");
   }
 
-  function syncJson(path) {
-    const request = new XMLHttpRequest();
-    request.open("GET", path, false);
-    request.withCredentials = true;
-    request.send(null);
-
-    if (request.status < 200 || request.status >= 300) {
-      const detail = request.responseText || `Request failed with ${request.status}`;
-      throw new Error(detail);
+  async function bootstrap() {
+    if (launchFromUrl) {
+      persistLaunchToken(launchFromUrl);
+      stripSensitiveQuery();
     }
 
-    return JSON.parse(request.responseText);
+    const launchToken = window.__RADSYSX_LAUNCH__ ? null : getStoredLaunchToken();
+    if (!launchToken && !window.__RADSYSX_LAUNCH__) {
+      throw new Error("The OHIF viewer requires a governed launch session.");
+    }
+
+    /** @type {SessionResponse} */
+    const session = await requestJson("/api/auth/session");
+    if (!session.authenticated || !session.session) {
+      if (launchToken) {
+        persistLaunchToken(launchToken);
+      }
+      window.location.replace("/login?next=%2Fviewer");
+      return;
+    }
+
+    /** @type {ImagingLaunchResolveResponse} */
+    let resolved = window.__RADSYSX_LAUNCH__;
+    if (!resolved) {
+      try {
+        resolved = await requestJson(
+          `/api/imaging/launch/resolve?launch=${encodeURIComponent(launchToken ?? "")}`,
+        );
+      } catch (error) {
+        clearStoredLaunchToken();
+        throw error;
+      }
+    }
+
+    window.__RADSYSX_LAUNCH__ = resolved;
+    window.__RADSYSX_CLEAN_VIEWER_URL__ = function cleanViewerUrl() {
+      history.replaceState(history.state, "", window.location.pathname);
+    };
+    clearStoredLaunchToken();
+    stripSensitiveQuery();
+    loader.dataset.state = "ready";
+    loader.querySelector("[data-role='title']").textContent = "Governed launch resolved";
+    loader.querySelector("[data-role='body']").textContent =
+      "Preparing the OHIF runtime and workspace panels.";
+  }
+
+  async function requestJson(path) {
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(path, {
+        credentials: "include",
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const detail = (await response.text()) || `Request failed with ${response.status}`;
+        throw new Error(detail);
+      }
+
+      return response.json();
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw new Error("Viewer bootstrap timed out while contacting the backend.");
+      }
+      throw error;
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
+  }
+
+  function stripSensitiveQuery() {
+    const cleanParams = new URLSearchParams(window.location.search);
+    cleanParams.delete("launch");
+    cleanParams.delete("StudyInstanceUIDs");
+    cleanParams.delete("studyInstanceUIDs");
+    cleanParams.delete("SeriesInstanceUIDs");
+    cleanParams.delete("seriesInstanceUIDs");
+    const nextUrl = cleanParams.toString()
+      ? `${window.location.pathname}?${cleanParams.toString()}`
+      : window.location.pathname;
+    history.replaceState(history.state, "", nextUrl);
+  }
+
+  function persistLaunchToken(token) {
+    try {
+      window.sessionStorage.setItem(LAUNCH_STORAGE_KEY, token);
+    } catch (error) {
+      console.warn("Unable to persist launch token for login handoff.", error);
+    }
+  }
+
+  function getStoredLaunchToken() {
+    try {
+      return window.sessionStorage.getItem(LAUNCH_STORAGE_KEY);
+    } catch (error) {
+      console.warn("Unable to read stored launch token.", error);
+      return null;
+    }
+  }
+
+  function clearStoredLaunchToken() {
+    try {
+      window.sessionStorage.removeItem(LAUNCH_STORAGE_KEY);
+    } catch (error) {
+      console.warn("Unable to clear stored launch token.", error);
+    }
   }
 
   function ensureLoader() {
@@ -73,7 +139,7 @@
     element.innerHTML = `
       <div class="radsysx-loader-card">
         <div class="radsysx-loader-kicker">RadSysX Clinical Viewer</div>
-        <div class="radsysx-loader-title" data-role="title">Resolving launch token</div>
+        <div class="radsysx-loader-title" data-role="title">Resolving governed launch</div>
         <div class="radsysx-loader-body" data-role="body">Preparing the OHIF runtime...</div>
       </div>
     `;

--- a/viewer/assets/radsysx-bootstrap.js
+++ b/viewer/assets/radsysx-bootstrap.js
@@ -9,12 +9,16 @@
   const loader = ensureLoader();
   const params = new URLSearchParams(window.location.search);
   const launchFromUrl = params.get("launch");
+  const initialViewerBasePath = normalizeViewerBasePath(window.location.pathname) ?? "/";
+
+  window.__RADSYSX_VIEWER_BASE_PATH__ = initialViewerBasePath;
 
   window.__RADSYSX_BOOTSTRAP_PROMISE__ = bootstrap();
 
   try {
     await window.__RADSYSX_BOOTSTRAP_PROMISE__;
   } catch (error) {
+    clearStoredLaunchToken();
     fail(error instanceof Error ? error.message : "Unable to bootstrap the viewer.");
   }
 
@@ -24,7 +28,7 @@
       stripSensitiveQuery();
     }
 
-    const launchToken = window.__RADSYSX_LAUNCH__ ? null : getStoredLaunchToken();
+    const launchToken = window.__RADSYSX_LAUNCH__ ? null : getStoredLaunchToken() ?? launchFromUrl;
     if (!launchToken && !window.__RADSYSX_LAUNCH__) {
       throw new Error("The OHIF viewer requires a governed launch session.");
     }
@@ -33,9 +37,17 @@
     const session = await requestJson("/api/auth/session");
     if (!session.authenticated || !session.session) {
       if (launchToken) {
-        persistLaunchToken(launchToken);
+        const preserved = persistLaunchToken(launchToken);
+        if (!preserved) {
+          clearStoredLaunchToken();
+          throw new Error(
+            "Sign-in is required, but the viewer could not preserve the governed launch for a login redirect.",
+          );
+        }
       }
-      window.location.replace("/login?next=%2Fviewer");
+      window.location.replace(
+        `/login?next=${encodeURIComponent(window.__RADSYSX_VIEWER_BASE_PATH__ ?? "/")}`,
+      );
       return;
     }
 
@@ -53,8 +65,13 @@
     }
 
     window.__RADSYSX_LAUNCH__ = resolved;
+    window.__RADSYSX_VIEWER_RUNTIME__ = resolved.viewerRuntime;
+    window.__RADSYSX_VIEWER_BASE_PATH__ =
+      normalizeViewerBasePath(resolved.viewerRuntime?.viewerBasePath) ??
+      window.__RADSYSX_VIEWER_BASE_PATH__;
+    applyResolvedViewerRuntime();
     window.__RADSYSX_CLEAN_VIEWER_URL__ = function cleanViewerUrl() {
-      history.replaceState(history.state, "", window.location.pathname);
+      stripSensitiveQuery();
     };
     clearStoredLaunchToken();
     stripSensitiveQuery();
@@ -103,11 +120,33 @@
     history.replaceState(history.state, "", nextUrl);
   }
 
+  function applyResolvedViewerRuntime() {
+    const runtime = window.__RADSYSX_VIEWER_RUNTIME__;
+    const config = window.config;
+    if (!runtime || !config) {
+      return;
+    }
+
+    config.routerBasename = window.__RADSYSX_VIEWER_BASE_PATH__ ?? config.routerBasename;
+
+    const dicomwebSource = config.dataSources?.find((entry) => entry?.sourceName === "dicomweb");
+    if (!dicomwebSource?.configuration) {
+      return;
+    }
+
+    dicomwebSource.configuration.qidoRoot = runtime.qidoRoot;
+    dicomwebSource.configuration.wadoRoot = runtime.wadoRoot;
+    dicomwebSource.configuration.wadoUriRoot = runtime.wadoUriRoot;
+    dicomwebSource.configuration.stowRoot = runtime.stowRoot;
+  }
+
   function persistLaunchToken(token) {
     try {
       window.sessionStorage.setItem(LAUNCH_STORAGE_KEY, token);
+      return true;
     } catch (error) {
       console.warn("Unable to persist launch token for login handoff.", error);
+      return false;
     }
   }
 
@@ -126,6 +165,20 @@
     } catch (error) {
       console.warn("Unable to clear stored launch token.", error);
     }
+  }
+
+  function normalizeViewerBasePath(value) {
+    if (!value) {
+      return null;
+    }
+
+    const trimmed = String(value).trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const normalized = trimmed.replace(/\/+$/, "");
+    return normalized || "/";
   }
 
   function ensureLoader() {

--- a/viewer/assets/radsysx-ohif-extension.js
+++ b/viewer/assets/radsysx-ohif-extension.js
@@ -11,6 +11,7 @@
   }
 
   const EXTENSION_ID = "@radsysx/extension-clinical";
+  const DEFAULT_DICOMWEB_NAMESPACE = "@ohif/extension-default.dataSourcesModule.dicomweb";
   const WORKSPACE_PANEL_ID = `${EXTENSION_ID}.panelModule.workspace`;
 
   class RadSysXWorkspacePanel extends HTMLElement {
@@ -375,17 +376,21 @@
         {
           name: "dicomweb",
           type: "webApi",
-          createDataSource(configuration) {
-            const defaultExtension = globalThis["ohif-extension-default"];
-            const defaultModule = defaultExtension
-              ?.getDataSourcesModule?.()
-              ?.find((module) => module.name === "dicomweb");
+          createDataSource(configuration, servicesManager, extensionManager) {
+            const defaultModule = extensionManager?.getModuleEntry?.(DEFAULT_DICOMWEB_NAMESPACE);
 
-            if (!defaultModule) {
+            if (!defaultModule?.createDataSource) {
               throw new Error("The default OHIF dicomweb data source is unavailable.");
             }
 
-            const dataSource = defaultModule.createDataSource(configuration);
+            const runtimeConfiguration = {
+              ...(configuration ?? {}),
+            };
+            const dataSource = defaultModule.createDataSource(
+              runtimeConfiguration,
+              servicesManager,
+              extensionManager,
+            );
             const originalInitialize = dataSource.initialize?.bind(dataSource);
             const originalGetStudyInstanceUIDs = dataSource.getStudyInstanceUIDs?.bind(dataSource);
             const originalRetrieveSeriesMetadata =
@@ -394,6 +399,7 @@
             if (originalInitialize) {
               dataSource.initialize = async function initialize(initArgs) {
                 await window.__RADSYSX_BOOTSTRAP_PROMISE__;
+                applyViewerRuntimeToDicomwebConfiguration(runtimeConfiguration);
                 return originalInitialize(initArgs);
               };
             }
@@ -512,9 +518,30 @@
       ...(args ?? {}),
       filters: {
         ...filters,
-        seriesInstanceUIDs,
+        seriesInstanceUID: seriesInstanceUIDs,
       },
     };
+  }
+
+  function applyViewerRuntimeToDicomwebConfiguration(configuration) {
+    const viewerRuntime = getViewerRuntime();
+    if (!viewerRuntime || !configuration) {
+      return configuration;
+    }
+
+    configuration.qidoRoot = viewerRuntime.qidoRoot || configuration.qidoRoot;
+    configuration.wadoRoot = viewerRuntime.wadoRoot || configuration.wadoRoot;
+    configuration.wadoUriRoot =
+      viewerRuntime.wadoUriRoot ||
+      viewerRuntime.wadoRoot ||
+      configuration.wadoUriRoot ||
+      configuration.wadoRoot;
+    configuration.stowRoot = viewerRuntime.stowRoot || configuration.stowRoot;
+    return configuration;
+  }
+
+  function getViewerRuntime() {
+    return window.__RADSYSX_VIEWER_RUNTIME__ ?? window.__RADSYSX_LAUNCH__?.viewerRuntime ?? null;
   }
 
   function getLaunchContext() {

--- a/viewer/assets/radsysx-ohif-extension.js
+++ b/viewer/assets/radsysx-ohif-extension.js
@@ -370,6 +370,57 @@
 
   window.__RADSYSX_OHIF_EXTENSION__ = {
     id: EXTENSION_ID,
+    getDataSourcesModule() {
+      return [
+        {
+          name: "dicomweb",
+          type: "webApi",
+          createDataSource(configuration) {
+            const defaultExtension = globalThis["ohif-extension-default"];
+            const defaultModule = defaultExtension
+              ?.getDataSourcesModule?.()
+              ?.find((module) => module.name === "dicomweb");
+
+            if (!defaultModule) {
+              throw new Error("The default OHIF dicomweb data source is unavailable.");
+            }
+
+            const dataSource = defaultModule.createDataSource(configuration);
+            const originalInitialize = dataSource.initialize?.bind(dataSource);
+            const originalGetStudyInstanceUIDs = dataSource.getStudyInstanceUIDs?.bind(dataSource);
+            const originalRetrieveSeriesMetadata =
+              dataSource.retrieve?.series?.metadata?.bind(dataSource.retrieve.series);
+
+            if (originalInitialize) {
+              dataSource.initialize = async function initialize(initArgs) {
+                await window.__RADSYSX_BOOTSTRAP_PROMISE__;
+                return originalInitialize(initArgs);
+              };
+            }
+
+            if (originalGetStudyInstanceUIDs) {
+              dataSource.getStudyInstanceUIDs = function getStudyInstanceUIDs(initArgs) {
+                const studyInstanceUIDs = originalGetStudyInstanceUIDs(initArgs);
+                if (studyInstanceUIDs?.filter(Boolean).length) {
+                  return studyInstanceUIDs;
+                }
+
+                const launchStudyUid = getLaunchContext()?.studyInstanceUID;
+                return launchStudyUid ? [launchStudyUid] : studyInstanceUIDs;
+              };
+            }
+
+            if (dataSource.retrieve?.series && originalRetrieveSeriesMetadata) {
+              dataSource.retrieve.series.metadata = function metadata(args) {
+                return originalRetrieveSeriesMetadata(injectLaunchSeriesFilters(args));
+              };
+            }
+
+            return dataSource;
+          },
+        },
+      ];
+    },
     getPanelModule() {
       return [
         {
@@ -435,5 +486,38 @@
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;");
+  }
+
+  function injectLaunchSeriesFilters(args) {
+    const launchContext = getLaunchContext();
+    const seriesInstanceUIDs = launchContext?.seriesInstanceUIDs ?? [];
+    if (seriesInstanceUIDs.length === 0) {
+      return args;
+    }
+
+    const filters = {
+      ...(args?.filters ?? {}),
+    };
+    const hasSeriesFilter =
+      filters.SeriesInstanceUID ||
+      filters.SeriesInstanceUIDs ||
+      filters.seriesInstanceUID ||
+      filters.seriesInstanceUIDs;
+
+    if (hasSeriesFilter) {
+      return args;
+    }
+
+    return {
+      ...(args ?? {}),
+      filters: {
+        ...filters,
+        seriesInstanceUIDs,
+      },
+    };
+  }
+
+  function getLaunchContext() {
+    return window.__RADSYSX_LAUNCH__?.context ?? null;
   }
 })();

--- a/viewer/scripts/build-ohif-dist.mjs
+++ b/viewer/scripts/build-ohif-dist.mjs
@@ -51,7 +51,7 @@ function writeAppConfig() {
 (function radsysxAppConfig() {
   window.config = {
     name: "config/radsysx-clinical.js",
-    routerBasename: "/viewer",
+    routerBasename: window.__RADSYSX_VIEWER_BASE_PATH__ ?? null,
     extensions: [
       "@ohif/extension-default",
       "@ohif/extension-cornerstone",
@@ -79,9 +79,9 @@ function writeAppConfig() {
         configuration: {
           friendlyName: "RadSysX Clinical DICOMweb",
           name: "radsysxOrthanc",
-          qidoRoot: "/dicom-web",
-          wadoRoot: "/dicom-web",
-          wadoUriRoot: "/dicom-web",
+          qidoRoot: null,
+          wadoRoot: null,
+          wadoUriRoot: null,
           qidoSupportsIncludeField: true,
           supportsReject: false,
           supportsStow: false,
@@ -106,22 +106,35 @@ function writeAppConfig() {
 function patchIndexHtml() {
   const indexPath = path.join(distRoot, "index.html");
   let html = fs.readFileSync(indexPath, "utf8");
+  const publicUrlBootstrap = [
+    "window.__RADSYSX_VIEWER_BASE_PATH__ = (function resolveViewerBasePath() {",
+    "  const pathname = window.location.pathname || '/';",
+    "  const normalized = pathname.replace(/\\/+$/, '');",
+    "  return normalized || '/';",
+    "})();",
+    "window.__RADSYSX_PUBLIC_URL__ =",
+    "  window.__RADSYSX_VIEWER_BASE_PATH__ === '/' ? '/' : `${window.__RADSYSX_VIEWER_BASE_PATH__}/`;",
+    "document.write('<base href=\"' + window.__RADSYSX_PUBLIC_URL__.replace(/\"/g, '&quot;') + '\">');",
+    "window.PUBLIC_URL = window.__RADSYSX_PUBLIC_URL__;",
+  ].join(" ");
 
-  html = html.replace("window.PUBLIC_URL = '/';", "window.PUBLIC_URL = '/viewer/';");
-  html = html.replace(/(src|href)=\"\//g, '$1="/viewer/');
+  html = html.replace("window.PUBLIC_URL = '/';", publicUrlBootstrap);
+  html = html.replace("window.PUBLIC_URL = '/';", "window.PUBLIC_URL = window.__RADSYSX_PUBLIC_URL__;");
+  html = html.replace(/(src|href|content)=\"\/assets\//g, '$1="assets/');
+  html = html.replace(/(src|href)=\"\//g, '$1="');
   html = html.replace(
-    '<script rel="preload" as="script" src="/viewer/app-config.js"></script>',
+    '<script rel="preload" as="script" src="app-config.js"></script>',
     [
-      '<script src="/viewer/react.production.min.js"></script>',
-      '<script src="/viewer/radsysx-bootstrap.js"></script>',
-      '<script src="/viewer/radsysx-ohif-extension.js"></script>',
-      '<script src="/viewer/radsysx-ohif-mode.js"></script>',
-      '<script rel="preload" as="script" src="/viewer/app-config.js"></script>',
+      '<script src="react.production.min.js"></script>',
+      '<script src="radsysx-bootstrap.js"></script>',
+      '<script src="radsysx-ohif-extension.js"></script>',
+      '<script src="radsysx-ohif-mode.js"></script>',
+      '<script rel="preload" as="script" src="app-config.js"></script>',
     ].join(""),
   );
   html = html.replace(
     "</head>",
-    '<link href="/viewer/radsysx-viewer.css" rel="stylesheet"></head>',
+    '<link href="radsysx-viewer.css" rel="stylesheet"></head>',
   );
 
   fs.writeFileSync(indexPath, html, "utf8");

--- a/viewer/scripts/build-ohif-dist.mjs
+++ b/viewer/scripts/build-ohif-dist.mjs
@@ -49,13 +49,10 @@ function copyWorkspaceAsset(relativeParts, outputName) {
 function writeAppConfig() {
   const config = `/** @type {AppTypes.Config} */
 (function radsysxAppConfig() {
-  const resolved = window.__RADSYSX_LAUNCH__;
-  const runtime = resolved?.viewerRuntime ?? {};
   window.config = {
     name: "config/radsysx-clinical.js",
-    routerBasename: runtime.viewerBasePath ?? "/viewer",
+    routerBasename: "/viewer",
     extensions: [
-      window.__RADSYSX_OHIF_EXTENSION__,
       "@ohif/extension-default",
       "@ohif/extension-cornerstone",
       "@ohif/extension-measurement-tracking",
@@ -63,6 +60,7 @@ function writeAppConfig() {
       "@ohif/extension-cornerstone-dicom-seg",
       "@ohif/extension-dicom-pdf",
       "@ohif/extension-dicom-video",
+      window.__RADSYSX_OHIF_EXTENSION__,
     ],
     modes: [
       window.__RADSYSX_OHIF_MODE__,
@@ -76,14 +74,14 @@ function writeAppConfig() {
     defaultDataSourceName: "dicomweb",
     dataSources: [
       {
-        namespace: "@ohif/extension-default.dataSourcesModule.dicomweb",
+        namespace: "@radsysx/extension-clinical.dataSourcesModule.dicomweb",
         sourceName: "dicomweb",
         configuration: {
           friendlyName: "RadSysX Clinical DICOMweb",
           name: "radsysxOrthanc",
-          qidoRoot: runtime.qidoRoot ?? "/dicom-web",
-          wadoRoot: runtime.wadoRoot ?? "/dicom-web",
-          wadoUriRoot: runtime.wadoUriRoot ?? "/dicom-web",
+          qidoRoot: "/dicom-web",
+          wadoRoot: "/dicom-web",
+          wadoUriRoot: "/dicom-web",
           qidoSupportsIncludeField: true,
           supportsReject: false,
           supportsStow: false,


### PR DESCRIPTION
This commit closes the actionable PR #51 review feedback and then updates the active project guidance so the next tranche starts from the real current baseline instead of stale migration-era assumptions.

The most important part of this work is the PR #51 polish and hardening pass:
- viewer URL and launch-token secrecy fixes
- async viewer bootstrap reliability improvements
- robust Orthanc credential templating
- de-identified clinical seed logging

It also updates the maintained guidance to reflect:
- the current post-Phase-4-polish RadSysX baseline
- Linux-first development/validation posture
- project operating rules to reduce future drift

## What Changed

### 1. Addressed actionable PR #51 comments

#### Viewer bootstrap hardening

The clinical viewer bootstrap was tightened to eliminate sensitive URL leakage and improve reliability.

Changes:
- replaced synchronous XHR with async `fetch`
- added timeout-bounded bootstrap requests
- stopped writing `StudyInstanceUIDs` / `SeriesInstanceUIDs` back into viewer URLs
- stopped leaking the opaque `launch` token through `/login?next=...`
- moved launch-token handoff for unauthenticated redirects into `sessionStorage`
- cleared persisted launch state after successful resolve and on failed resolve paths

Files:
- `viewer/assets/radsysx-bootstrap.js`

#### OHIF runtime integration cleanup

The viewer no longer depends on URL query parameters for governed study context.

Changes:
- added a RadSysX-owned OHIF dicomweb data source wrapper
- let OHIF read governed launch context from resolved RadSysX state instead of URL params
- preserved series filtering by injecting launch-derived series filters inside the data source layer
- kept the bootstrap layer focused on session validation, launch resolution, and startup cleanup

Files:
- `viewer/assets/radsysx-ohif-extension.js`
- `viewer/scripts/build-ohif-dist.mjs`

#### Orthanc config templating fix

The compose-based Orthanc startup path was hardened so credentials are expanded correctly and safely.

Changes:
- replaced the fragile inline `sed` templating command in `docker-compose.yml`
- added a dedicated `render-orthanc-config.sh` helper
- handled characters that previously broke config rendering or JSON output, including `/`, `&`, `|`, `\`, and `"`
- removed dependence on shell-quoting behavior that could leave literal env variable strings in Orthanc config

Files:
- `deploy/clinical-stack/render-orthanc-config.sh`
- `docker-compose.yml`

#### Logging hygiene

The clinical Orthanc seeding path no longer logs accession numbers.

Changes:
- replaced identifier-bearing seed logs with generic sample ordinals plus modality
- extended tests so seeded study UIDs, patient names, and accession numbers are all excluded from log output

Files:
- `backend/clinical/seed_orthanc.py`
- `backend/tests/test_clinical_platform.py`

### 2. Refreshed guidance for the current baseline

The maintained guidance set was updated to describe the actual current state of the repo, not earlier migration checkpoints.

Updated:
- `AGENTS.md`
- `README.md`
- `CLAUDE.md`
- `WARP.md`
- `PHASE4_CLINICAL_EXECUTION_CHECKLIST.md`

Changes:
- removed stale “after Phase 3” / old-checklist framing
- reframed the checklist around the current post-Phase-4-polish baseline
- removed hardcoded branch-era references that no longer belong in standing guidance
- made the environment posture Linux-first and Linux-generic
- removed WSL / Docker Desktop / Windows-specific guidance assumptions
- documented that new-machine work should begin with quick recon, then wait for the first user-reported Linux runtime test result before widening the change scope

### 3. Added durable project operating rules

`AGENTS.md` now includes a concise operating rule set based on issues encountered during this tranche.

New rule themes:
- update docs in the same tranche as behavior/env/architecture changes
- keep `AGENTS.md` authoritative and companion docs aligned
- preserve the research-vs-clinical boundary
- prefer backend-authoritative contracts for governed workflows
- keep the viewer bootstrap minimal
- avoid normalizing insecure or machine-local hacks into maintained guidance
- make environment setup reproducible from the repo
- turn recurring review findings into durable guidance
- clearly state what was and was not verified

## Why This Matters

PR #51 surfaced the right class of issues for a governed clinical runtime:
- launch/session secrecy regressions
- brittle bootstrap behavior
- incorrect compose templating under real credential values
- identifier-bearing logs
- guidance drift away from the shipped runtime

This commit fixes those issues and leaves the repo in a cleaner state for the next Linux-based validation and the next clinical tranche.

## Validation

Passed:
- `python3 -m compileall backend/clinical backend/server.py`
- `PYTHONPATH=/tmp/novion-phase3-pydeps-fast python3 -m pytest backend/tests/test_clinical_platform.py --capture=no`
  - result: `16 passed, 1 skipped`
- Orthanc templating edge-case validation with special-character credentials
- `npm run type-check --workspace viewer`
- `npm run build --workspace viewer`

Notes:
- the viewer checks passed successfully
- the final guidance-only edits were not followed by another runtime test pass because they did not change executable behavior

## Follow-Up

The next tranche should start from the updated guidance and current runtime baseline:

1. do quick recon on the Linux machine
2. wait for the first user-reported Linux runtime test results
3. triage observed issues first
4. then continue with deeper OHIF-native integration and governed SR/SEG export-reload work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer Linux-focused setup and validation procedures with explicit installation steps.
  * Updated host environment prerequisites and bootstrap guidance.

* **Security & Features**
  * Improved launch token handling with secure URL parameter stripping.
  * Implemented environment variable-based credential configuration.
  * Enhanced DICOM viewer launch context filtering.

* **Bug Fixes**
  * Strengthened asynchronous bootstrap flow for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->